### PR TITLE
feat: add linux arm64/aarch64 support for Tor binary download

### DIFF
--- a/packages/backend/src/binary/metadata.ts
+++ b/packages/backend/src/binary/metadata.ts
@@ -29,6 +29,9 @@ function getPlatformIdentifier(): Result<PlatformIdentifier> {
   if (platform === "linux" && arch === "x64") {
     return { kind: "Ok", value: { os: "linux", arch: "x86_64" } };
   }
+  if (platform === "linux" && arch === "arm64") {
+    return { kind: "Ok", value: { os: "linux", arch: "aarch64" } };
+  }
 
   if (platform === "win32" && arch === "x64") {
     return { kind: "Ok", value: { os: "windows", arch: "x86_64" } };
@@ -43,6 +46,10 @@ function getPlatformIdentifier(): Result<PlatformIdentifier> {
 function buildMetadataUrl(platform: PlatformIdentifier): string {
   if (platform.os === "macos") {
     return `${METADATA_BASE_URL}/download-${platform.os}.json`;
+  }
+  // linux-aarch64 only exists in the alpha channel
+  if (platform.os === "linux" && platform.arch === "aarch64") {
+    return `${METADATA_BASE_URL.replace("/release", "/alpha")}/download-linux-aarch64.json`;
   }
   return `${METADATA_BASE_URL}/download-${platform.os}-${platform.arch}.json`;
 }


### PR DESCRIPTION
Problem
Linux arm64 (aarch64) was not a recognized platform in getPlatformIdentifier(), causing the plugin to return "unsupported platform linux arm64" when trying to download the Tor binary. This affects users running Kali Linux (and other distros) on ARM hardware such as Apple Silicon Macs via Parallels.
Fix

Added linux arm64 → linux-aarch64 mapping in getPlatformIdentifier()
Pointed linux-aarch64 at the alpha metadata channel (update_3/alpha) since the stable channel does not publish a download-linux-aarch64.json — the binary itself downloads and runs correctly

Tested on
Kali Linux aarch64 in Parallels on Apple M4
